### PR TITLE
Add Brasileirão simulation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Brasileirão Simulator
+
+This project provides a simple simulator for the 2024 Brasileirão Série A season. It parses the fixtures provided in `data/Brasileirao2024A.txt`, builds a league table from played matches, and simulates the remaining games many times to estimate title probabilities.
+
+## Usage
+
+Install dependencies and run the simulator:
+
+```bash
+pip install pandas numpy
+python main.py --simulations 1000
+```
+
+The script outputs the estimated chance of winning the title for each team.
+
+## Project Layout
+
+- `data/` – raw fixtures and results.
+- `src/brasileirao/simulator.py` – parsing, table calculation and simulation routines.
+- `main.py` – command-line interface to run the simulation.
+- `tests/` – basic unit tests.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+import argparse
+from src.brasileirao.simulator import parse_matches, simulate_chances, league_table
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate Brasileirão 2024 title odds")
+    parser.add_argument("--file", default="data/Brasileirao2024A.txt", help="fixture file path")
+    parser.add_argument("--simulations", type=int, default=1000, help="number of simulation runs")
+    args = parser.parse_args()
+
+    matches = parse_matches(args.file)
+    chances = simulate_chances(matches, iterations=args.simulations)
+
+    print("Title chances:")
+    for team, prob in sorted(chances.items(), key=lambda x: x[1], reverse=True):
+        print(f"{team:15s} {prob:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import re
+from pathlib import Path
+
+SCORE_PATTERN = re.compile(r"(\d+/\d+/\d+)\s+(.+?)\s+(\d+)-(\d+)\s+(.+?)\s*(?:\(ID:.*)?$")
+NOSCORE_PATTERN = re.compile(r"(\d+/\d+/\d+)\s+(.+?)\s{2,}(.+?)\s*(?:\(ID:.*)?$")
+
+
+def parse_matches(path: str | Path) -> pd.DataFrame:
+    """Parse the fixture text file into a DataFrame."""
+    rows: list[dict] = []
+    in_games = False
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            if line.strip() == 'GamesBegin':
+                in_games = True
+                continue
+            if line.strip() == 'GamesEnd':
+                break
+            if not in_games:
+                continue
+            line = line.rstrip('\n')
+            m = SCORE_PATTERN.match(line)
+            if m:
+                date_str, home, hs, as_, away = m.groups()
+                rows.append({
+                    'date': pd.to_datetime(date_str),
+                    'home_team': home.strip(),
+                    'away_team': away.strip(),
+                    'home_score': int(hs),
+                    'away_score': int(as_),
+                })
+                continue
+            m = NOSCORE_PATTERN.match(line)
+            if m:
+                date_str, home, away = m.groups()
+                rows.append({
+                    'date': pd.to_datetime(date_str),
+                    'home_team': home.strip(),
+                    'away_team': away.strip(),
+                    'home_score': np.nan,
+                    'away_score': np.nan,
+                })
+    return pd.DataFrame(rows)
+
+
+def league_table(matches: pd.DataFrame) -> pd.DataFrame:
+    """Compute league standings from match results."""
+    teams = pd.unique(matches[['home_team', 'away_team']].values.ravel())
+    table = {t: {'team': t, 'played': 0, 'wins': 0, 'draws': 0, 'losses': 0, 'gf': 0, 'ga': 0} for t in teams}
+
+    played = matches.dropna(subset=['home_score', 'away_score'])
+    for _, row in played.iterrows():
+        home = row['home_team']
+        away = row['away_team']
+        hs = int(row['home_score'])
+        as_ = int(row['away_score'])
+        table[home]['played'] += 1
+        table[away]['played'] += 1
+        table[home]['gf'] += hs
+        table[home]['ga'] += as_
+        table[away]['gf'] += as_
+        table[away]['ga'] += hs
+        if hs > as_:
+            table[home]['wins'] += 1
+            table[home]['points'] = table[home].get('points', 0) + 3
+            table[away]['losses'] += 1
+            table[away].setdefault('points', 0)
+        elif hs < as_:
+            table[away]['wins'] += 1
+            table[away]['points'] = table[away].get('points', 0) + 3
+            table[home]['losses'] += 1
+            table[home].setdefault('points', 0)
+        else:
+            table[home]['draws'] += 1
+            table[away]['draws'] += 1
+            table[home]['points'] = table[home].get('points', 0) + 1
+            table[away]['points'] = table[away].get('points', 0) + 1
+
+    for t in table.values():
+        t.setdefault('points', 0)
+        t['gd'] = t['gf'] - t['ga']
+
+    df = pd.DataFrame(table.values())
+    df = df.sort_values(['points', 'gd', 'gf'], ascending=False).reset_index(drop=True)
+    return df
+
+
+def _estimate_strengths(matches: pd.DataFrame):
+    played = matches.dropna(subset=['home_score', 'away_score'])
+    total_goals = played['home_score'].sum() + played['away_score'].sum()
+    total_games = len(played)
+    avg_goals = total_goals / total_games if total_games else 2.5
+    home_adv = played['home_score'].sum() / played['away_score'].sum() if played['away_score'].sum() else 1.0
+
+    teams = pd.unique(matches[['home_team', 'away_team']].values.ravel())
+    strengths = {}
+    for team in teams:
+        gf = (
+            played.loc[played.home_team == team, 'home_score'].sum() +
+            played.loc[played.away_team == team, 'away_score'].sum()
+        )
+        ga = (
+            played.loc[played.home_team == team, 'away_score'].sum() +
+            played.loc[played.away_team == team, 'home_score'].sum()
+        )
+        gp = played.loc[(played.home_team == team) | (played.away_team == team)].shape[0]
+        if gp == 0:
+            attack = defense = 1.0
+        else:
+            attack = (gf / gp) / avg_goals
+            defense = (ga / gp) / avg_goals
+        strengths[team] = {'attack': attack, 'defense': defense}
+    return strengths, avg_goals, home_adv
+
+
+def simulate_chances(matches: pd.DataFrame, iterations: int = 1000) -> dict[str, float]:
+    """Simulate remaining fixtures and return title probabilities."""
+    strengths, avg_goals, home_adv = _estimate_strengths(matches)
+    teams = pd.unique(matches[['home_team', 'away_team']].values.ravel())
+    champs = {t: 0 for t in teams}
+
+    played_df = matches.dropna(subset=['home_score', 'away_score'])
+    remaining = matches[matches['home_score'].isna() | matches['away_score'].isna()]
+
+    for _ in range(iterations):
+        sims = []
+        for _, row in remaining.iterrows():
+            ht = row['home_team']
+            at = row['away_team']
+            mu_home = avg_goals * strengths[ht]['attack'] * strengths[at]['defense'] * home_adv
+            mu_away = avg_goals * strengths[at]['attack'] * strengths[ht]['defense']
+            hs = np.random.poisson(mu_home)
+            as_ = np.random.poisson(mu_away)
+            sims.append({'date': row['date'], 'home_team': ht, 'away_team': at, 'home_score': hs, 'away_score': as_})
+        all_matches = pd.concat([played_df, pd.DataFrame(sims)], ignore_index=True)
+        table = league_table(all_matches)
+        champs[table.iloc[0]['team']] += 1
+
+    for t in champs:
+        champs[t] = champs[t] / iterations
+    return champs

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,23 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+import pandas as pd
+from brasileirao import simulator
+
+
+def test_parse_matches():
+    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    assert len(df) == 380
+    assert {'home_team', 'away_team', 'home_score', 'away_score'}.issubset(df.columns)
+
+
+def test_league_table():
+    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    table = simulator.league_table(df)
+    # after first rounds some teams have points
+    assert 'points' in table.columns
+    assert table['played'].max() > 0
+
+
+def test_simulate_chances():
+    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    chances = simulator.simulate_chances(df, iterations=10)
+    assert abs(sum(chances.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- implement match parser and simulator in `src/brasileirao/simulator.py`
- add CLI to run simulations in `main.py`
- document usage in `README.md`
- add unit tests for parser and simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d873e408832587ad6af086ecbca2