### PR TITLE
Update to Brasileirão 2025 season

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brasileirão Simulator
 
-This project provides a simple simulator for the 2024 Brasileirão Série A season. It parses the fixtures provided in `data/Brasileirao2024A.txt`, builds a league table from played matches, and simulates the remaining games many times to estimate title probabilities.
+This project provides a simple simulator for the 2025 Brasileirão Série A season. It parses the fixtures provided in `data/Brasileirao2025A.txt`, builds a league table from played matches, and simulates the remaining games many times to estimate title probabilities.
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ from src.brasileirao.simulator import parse_matches, simulate_chances, league_ta
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Simulate Brasileirão 2024 title odds")
-    parser.add_argument("--file", default="data/Brasileirao2024A.txt", help="fixture file path")
+    parser = argparse.ArgumentParser(description="Simulate Brasileirão 2025 title odds")
+    parser.add_argument("--file", default="data/Brasileirao2025A.txt", help="fixture file path")
     parser.add_argument("--simulations", type=int, default=1000, help="number of simulation runs")
     args = parser.parse_args()
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -4,13 +4,13 @@ from brasileirao import simulator
 
 
 def test_parse_matches():
-    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    df = simulator.parse_matches('data/Brasileirao2025A.txt')
     assert len(df) == 380
     assert {'home_team', 'away_team', 'home_score', 'away_score'}.issubset(df.columns)
 
 
 def test_league_table():
-    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    df = simulator.parse_matches('data/Brasileirao2025A.txt')
     table = simulator.league_table(df)
     # after first rounds some teams have points
     assert 'points' in table.columns
@@ -18,6 +18,6 @@ def test_league_table():
 
 
 def test_simulate_chances():
-    df = simulator.parse_matches('data/Brasileirao2024A.txt')
+    df = simulator.parse_matches('data/Brasileirao2025A.txt')
     chances = simulator.simulate_chances(df, iterations=10)
     assert abs(sum(chances.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- update README to mention 2025 season and fixture file
- default CLI fixture file to 2025 season
- adjust unit tests to use the 2025 data file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e1cbadbc8325a06a2c1c176283fd