### PR TITLE
Add Poisson rating option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ This project provides a simple simulator for the 2025 Brasileirão Série A seas
 Install dependencies and run the simulator:
 
 ```bash
-pip install pandas numpy
-python main.py --simulations 1000
+pip install pandas numpy statsmodels
+python main.py --simulations 1000 --rating poisson
 ```
+
+The `--rating` option accepts `ratio` (default) or `poisson` to choose how team
+strengths are estimated.
 
 The script outputs the estimated chance of winning the title for each team.
 

--- a/main.py
+++ b/main.py
@@ -6,10 +6,18 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Simulate Brasileirão 2025 title odds")
     parser.add_argument("--file", default="data/Brasileirao2025A.txt", help="fixture file path")
     parser.add_argument("--simulations", type=int, default=1000, help="number of simulation runs")
+    parser.add_argument(
+        "--rating",
+        default="ratio",
+        choices=["ratio", "poisson"],
+        help="team strength estimation method",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
-    chances = simulate_chances(matches, iterations=args.simulations)
+    chances = simulate_chances(
+        matches, iterations=args.simulations, rating_method=args.rating
+    )
 
     print("Title chances:")
     for team, prob in sorted(chances.items(), key=lambda x: x[1], reverse=True):

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -21,3 +21,9 @@ def test_simulate_chances():
     df = simulator.parse_matches('data/Brasileirao2025A.txt')
     chances = simulator.simulate_chances(df, iterations=10)
     assert abs(sum(chances.values()) - 1.0) < 1e-6
+
+
+def test_simulate_chances_poisson():
+    df = simulator.parse_matches('data/Brasileirao2025A.txt')
+    chances = simulator.simulate_chances(df, iterations=10, rating_method="poisson")
+    assert abs(sum(chances.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- implement Poisson-based strength estimation
- allow choosing rating method in simulate_chances and CLI
- document rating option
- verify Poisson rating via unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e8409ffc832587fb75b94938c385