### PR TITLE
Add seed control for simulation RNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ python main.py --simulations 1000 --rating poisson
 ```
 
 The `--rating` option accepts `ratio` (default) or `poisson` to choose how team
-strengths are estimated.
+strengths are estimated. Use the `--seed` option to set a random seed and
+reproduce a specific simulation.
 
 The script outputs the estimated chance of winning the title for each team.
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import argparse
+import numpy as np
 from src.brasileirao.simulator import parse_matches, simulate_chances, league_table
 
 
@@ -12,11 +13,21 @@ def main() -> None:
         choices=["ratio", "poisson"],
         help="team strength estimation method",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="random seed for repeatable simulations",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
+    rng = np.random.default_rng(args.seed) if args.seed is not None else None
     chances = simulate_chances(
-        matches, iterations=args.simulations, rating_method=args.rating
+        matches,
+        iterations=args.simulations,
+        rating_method=args.rating,
+        rng=rng,
     )
 
     print("Title chances:")

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -180,8 +180,24 @@ def simulate_chances(
     matches: pd.DataFrame,
     iterations: int = 1000,
     rating_method: str = "ratio",
+    rng: np.random.Generator | None = None,
 ) -> dict[str, float]:
-    """Simulate remaining fixtures and return title probabilities."""
+    """Simulate remaining fixtures and return title probabilities.
+
+    Parameters
+    ----------
+    matches : pd.DataFrame
+        DataFrame containing all fixtures. Played games must have scores.
+    iterations : int, default 1000
+        Number of simulation runs.
+    rating_method : str, default "ratio"
+        Method used to estimate team strengths.
+    rng : np.random.Generator | None, optional
+        Random number generator to use. A new generator is created when ``None``.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+
     if rating_method == "poisson":
         strengths, avg_goals, home_adv = estimate_poisson_strengths(matches)
     else:
@@ -199,8 +215,8 @@ def simulate_chances(
             at = row['away_team']
             mu_home = avg_goals * strengths[ht]['attack'] * strengths[at]['defense'] * home_adv
             mu_away = avg_goals * strengths[at]['attack'] * strengths[ht]['defense']
-            hs = np.random.poisson(mu_home)
-            as_ = np.random.poisson(mu_away)
+            hs = rng.poisson(mu_home)
+            as_ = rng.poisson(mu_away)
             sims.append({'date': row['date'], 'home_team': ht, 'away_team': at, 'home_score': hs, 'away_score': as_})
         all_matches = pd.concat([played_df, pd.DataFrame(sims)], ignore_index=True)
         table = league_table(all_matches)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,5 +1,6 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 import pandas as pd
+import numpy as np
 from brasileirao import simulator
 
 
@@ -27,3 +28,12 @@ def test_simulate_chances_poisson():
     df = simulator.parse_matches('data/Brasileirao2025A.txt')
     chances = simulator.simulate_chances(df, iterations=10, rating_method="poisson")
     assert abs(sum(chances.values()) - 1.0) < 1e-6
+
+
+def test_simulate_chances_seed_repeatability():
+    df = simulator.parse_matches('data/Brasileirao2025A.txt')
+    rng = np.random.default_rng(1234)
+    chances1 = simulator.simulate_chances(df, iterations=5, rng=rng)
+    rng = np.random.default_rng(1234)
+    chances2 = simulator.simulate_chances(df, iterations=5, rng=rng)
+    assert chances1 == chances2


### PR DESCRIPTION
## Summary
- allow passing an RNG into `simulate_chances`
- support a `--seed` option in the CLI
- update README with seed usage
- ensure deterministic output when using a seed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e94664e08325a1ff0012de9427d8