### PR TITLE
Expose core functions via brasileirao package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ The script outputs the estimated chance of winning the title for each team.
 - `src/brasileirao/simulator.py` – parsing, table calculation and simulation routines.
 - `main.py` – command-line interface to run the simulation.
 - `tests/` – basic unit tests.
+
+The main functions can be imported directly from the package:
+
+```python
+from brasileirao import parse_matches, league_table, simulate_chances
+```

--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
 import argparse
+import os
+import sys
 import numpy as np
-from src.brasileirao.simulator import parse_matches, simulate_chances, league_table
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+from brasileirao import parse_matches, simulate_chances, league_table
 
 
 def main() -> None:

--- a/src/brasileirao/__init__.py
+++ b/src/brasileirao/__init__.py
@@ -1,0 +1,6 @@
+"""Convenience exports for the simulator package."""
+
+from .simulator import league_table, parse_matches, simulate_chances
+
+__all__ = ["parse_matches", "league_table", "simulate_chances"]
+

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,46 +1,47 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 import pandas as pd
 import numpy as np
+from brasileirao import parse_matches, league_table, simulate_chances
 from brasileirao import simulator
 
 
 def test_parse_matches():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
+    df = parse_matches('data/Brasileirao2025A.txt')
     assert len(df) == 380
     assert {'home_team', 'away_team', 'home_score', 'away_score'}.issubset(df.columns)
 
 
 def test_league_table():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
-    table = simulator.league_table(df)
+    df = parse_matches('data/Brasileirao2025A.txt')
+    table = league_table(df)
     # after first rounds some teams have points
     assert 'points' in table.columns
     assert table['played'].max() > 0
 
 
 def test_simulate_chances():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
-    chances = simulator.simulate_chances(df, iterations=10)
+    df = parse_matches('data/Brasileirao2025A.txt')
+    chances = simulate_chances(df, iterations=10)
     assert abs(sum(chances.values()) - 1.0) < 1e-6
 
 
 def test_simulate_chances_poisson():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
-    chances = simulator.simulate_chances(df, iterations=10, rating_method="poisson")
+    df = parse_matches('data/Brasileirao2025A.txt')
+    chances = simulate_chances(df, iterations=10, rating_method="poisson")
     assert abs(sum(chances.values()) - 1.0) < 1e-6
 
 
 def test_simulate_chances_seed_repeatability():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
+    df = parse_matches('data/Brasileirao2025A.txt')
     rng = np.random.default_rng(1234)
-    chances1 = simulator.simulate_chances(df, iterations=5, rng=rng)
+    chances1 = simulate_chances(df, iterations=5, rng=rng)
     rng = np.random.default_rng(1234)
-    chances2 = simulator.simulate_chances(df, iterations=5, rng=rng)
+    chances2 = simulate_chances(df, iterations=5, rng=rng)
     assert chances1 == chances2
 
 
 def test_estimate_strengths():
-    df = simulator.parse_matches('data/Brasileirao2025A.txt')
+    df = parse_matches('data/Brasileirao2025A.txt')
     strengths, _, _ = simulator._estimate_strengths(df)
     teams = pd.unique(df[["home_team", "away_team"]].values.ravel())
 


### PR DESCRIPTION
## Summary
- expose `parse_matches`, `league_table` and `simulate_chances` at the package level
- adjust main script and tests to use the new import path
- document the new import location in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871eae0a6c0832596ef2e03abb27123