### PR TITLE
Add historic_ratio strength estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ pip install pandas numpy statsmodels
 python main.py --simulations 1000 --rating poisson
 ```
 
-The `--rating` option accepts `ratio` (default) or `poisson` to choose how team
-strengths are estimated. Use the `--seed` option to set a random seed and
+The `--rating` option accepts `ratio` (default), `historic_ratio`, or `poisson`
+to choose how team strengths are estimated. The `historic_ratio` method mixes
+results from the 2024 season with a lower weight. Use the `--seed` option to set a random seed and
 reproduce a specific simulation.
 
 The script outputs the estimated chance of winning the title for each team.

--- a/main.py
+++ b/main.py
@@ -14,8 +14,8 @@ def main() -> None:
     parser.add_argument(
         "--rating",
         default="ratio",
-        choices=["ratio", "poisson"],
-        help="team strength estimation method",
+        choices=["ratio", "historic_ratio", "poisson"],
+        help="team strength estimation method (use 'historic_ratio' to include past season)",
     )
     parser.add_argument(
         "--seed",

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -50,3 +50,16 @@ def test_estimate_strengths():
 
     # all estimated attack and defense values must be positive
     assert all(v["attack"] > 0 and v["defense"] > 0 for v in strengths.values())
+
+
+def test_estimate_strengths_with_history():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    strengths, _, _ = simulator.estimate_strengths_with_history(df)
+    teams = pd.unique(df[["home_team", "away_team"]].values.ravel())
+    assert set(teams).issubset(set(strengths.keys()))
+
+
+def test_simulate_chances_historic_ratio():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    chances = simulate_chances(df, iterations=10, rating_method="historic_ratio")
+    assert abs(sum(chances.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- add ability to estimate strengths using past season data
- support `historic_ratio` rating method in the simulator and CLI
- document the new option in README
- test historic strength estimation and simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ed7c94e48325bfc149c35db74f3b