### PR TITLE
Add CLI option for Elo K factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The `--rating` option accepts `ratio` (default), `historic_ratio`, `poisson`, or
 mixes results from the 2024 season with a lower weight. The `elo` method
 updates team ratings over time using an Elo formula; the `simulate_chances`
 function exposes an `elo_k` parameter for deterministic runs. Use the
-`--seed` option to set a random seed and reproduce a specific simulation.
+`--elo-k` CLI option or the `elo_k` function parameter to adjust the update
+factor (default `20.0`). Use the `--seed` option to set a random seed and
+reproduce a specific simulation.
 
 The script outputs the estimated chance of winning the title for each team.
 

--- a/main.py
+++ b/main.py
@@ -23,6 +23,12 @@ def main() -> None:
         default=None,
         help="random seed for repeatable simulations",
     )
+    parser.add_argument(
+        "--elo-k",
+        type=float,
+        default=20.0,
+        help="Elo K factor when using the 'elo' rating method",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -32,6 +38,7 @@ def main() -> None:
         iterations=args.simulations,
         rating_method=args.rating,
         rng=rng,
+        elo_k=args.elo_k,
     )
 
     print("Title chances:")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -87,6 +87,27 @@ def test_simulate_chances_elo_seed_repeatability():
     assert abs(sum(chances1.values()) - 1.0) < 1e-6
 
 
+def test_elo_k_value_changes_results():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    rng = np.random.default_rng(99)
+    chances_low = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="elo",
+        rng=rng,
+        elo_k=5.0,
+    )
+    rng = np.random.default_rng(99)
+    chances_high = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="elo",
+        rng=rng,
+        elo_k=40.0,
+    )
+    assert chances_low != chances_high
+
+
 def test_simulate_chances_neg_binom_seed_repeatability():
     df = parse_matches('data/Brasileirao2025A.txt')
     rng = np.random.default_rng(7)


### PR DESCRIPTION
## Summary
- make the Elo K factor configurable via `--elo-k` argument
- document the new option in README
- verify Elo K affects output with a new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f575fc508325832afde29d7f6c3a