### PR TITLE
Ensure deterministic league standings

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -94,7 +94,7 @@ def league_table(matches: pd.DataFrame) -> pd.DataFrame:
         t['gd'] = t['gf'] - t['ga']
 
     df = pd.DataFrame(table.values())
-    df = df.sort_values(['points', 'gd', 'gf'], ascending=False).reset_index(drop=True)
+    df = df.sort_values(['points', 'gd', 'gf', 'team'], ascending=[False, False, False, True]).reset_index(drop=True)
     return df
 
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -19,6 +19,35 @@ def test_league_table():
     assert table['played'].max() > 0
 
 
+def test_league_table_deterministic_sorting():
+    data = [
+        {
+            'date': '2025-01-01',
+            'home_team': 'Alpha',
+            'away_team': 'Beta',
+            'home_score': 1,
+            'away_score': 0,
+        },
+        {
+            'date': '2025-01-02',
+            'home_team': 'Beta',
+            'away_team': 'Gamma',
+            'home_score': 1,
+            'away_score': 0,
+        },
+        {
+            'date': '2025-01-03',
+            'home_team': 'Gamma',
+            'away_team': 'Alpha',
+            'home_score': 1,
+            'away_score': 0,
+        },
+    ]
+    df = pd.DataFrame(data)
+    table = league_table(df)
+    assert list(table.team) == sorted(table.team)
+
+
 def test_simulate_chances():
     df = parse_matches('data/Brasileirao2025A.txt')
     chances = simulate_chances(df, iterations=10)


### PR DESCRIPTION
## Summary
- sort by `team` as final tiebreaker in `league_table`
- add regression test verifying alphabetical ordering for identical stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f63e3b0c8325873d6a16db008fa3