### PR TITLE
Enhance simulator with team-specific home advantage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ updates team ratings over time using an Elo formula; the `simulate_chances`
 function exposes an `elo_k` parameter for deterministic runs. Use the
 `--elo-k` CLI option or the `elo_k` function parameter to adjust the update
 factor (default `20.0`). Use the `--seed` option to set a random seed and
-reproduce a specific simulation.
+reproduce a specific simulation. You can also specify team-specific home
+advantage multipliers by passing a dictionary to the `team_home_advantages`
+argument of `simulate_chances`.
 
 The script outputs the estimated chance of winning the title for each team.
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -155,3 +155,17 @@ def test_simulate_chances_neg_binom_seed_repeatability():
     )
     assert chances1 == chances2
     assert abs(sum(chances1.values()) - 1.0) < 1e-6
+
+
+def test_team_home_advantage_changes_results():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    rng = np.random.default_rng(11)
+    base = simulate_chances(df, iterations=5, rng=rng)
+    rng = np.random.default_rng(11)
+    custom = simulate_chances(
+        df,
+        iterations=5,
+        rng=rng,
+        team_home_advantages={"Bahia": 2.0},
+    )
+    assert base != custom


### PR DESCRIPTION
## Summary
- introduce `_estimate_team_home_advantages` helper to compute relative home strength
- allow passing `team_home_advantages` to `simulate_chances`
- test that custom home advantage alters simulation
- document the new feature in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871f709edf08325b408af35f1feb21d