### PR TITLE
Add Dixon-Coles rating method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ pip install pandas numpy statsmodels
 python main.py --simulations 1000 --rating poisson
 ```
 
-The `--rating` option accepts `ratio` (default), `historic_ratio`, `poisson`, or
-`elo` to choose how team strengths are estimated. The `historic_ratio` method
+The `--rating` option accepts `ratio` (default), `historic_ratio`, `poisson`,
+`neg_binom`, `dixon_coles`, or `elo` to choose how team strengths are
+estimated. The `historic_ratio` method
 mixes results from the 2024 season with a lower weight. The `elo` method
 updates team ratings over time using an Elo formula; the `simulate_chances`
 function exposes an `elo_k` parameter for deterministic runs. Use the

--- a/src/brasileirao/__init__.py
+++ b/src/brasileirao/__init__.py
@@ -1,6 +1,16 @@
 """Convenience exports for the simulator package."""
 
-from .simulator import league_table, parse_matches, simulate_chances
+from .simulator import (
+    league_table,
+    parse_matches,
+    simulate_chances,
+    estimate_dixon_coles_strengths,
+)
 
-__all__ = ["parse_matches", "league_table", "simulate_chances"]
+__all__ = [
+    "parse_matches",
+    "league_table",
+    "simulate_chances",
+    "estimate_dixon_coles_strengths",
+]
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -169,3 +169,23 @@ def test_team_home_advantage_changes_results():
         team_home_advantages={"Bahia": 2.0},
     )
     assert base != custom
+
+
+def test_simulate_chances_dixon_coles_seed_repeatability():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(123)
+    chances1 = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="dixon_coles",
+        rng=rng,
+    )
+    rng = np.random.default_rng(123)
+    chances2 = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="dixon_coles",
+        rng=rng,
+    )
+    assert chances1 == chances2
+    assert abs(sum(chances1.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- implement `estimate_dixon_coles_strengths` and sampling routine
- support new `dixon_coles` rating method in simulation
- export new function in package
- document new option in README
- test deterministic results for Dixon-Coles method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68726e196a048325ba6102cd47da0d4e