### PR TITLE
Add advanced league tie-break rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ with `--leader-history-paths` and `--leader-weight`.
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.
 
+## Tie-break Rules
+
+When building the league table teams are ordered using the official Série A
+criteria:
+
+1. Points
+2. Number of wins
+3. Goal difference
+4. Goals scored
+5. Points obtained in the games between the tied sides
+6. Team name (alphabetical)
+
+These rules are implemented in :func:`league_table` and therefore affect all
+simulation utilities.
+
 ## Project Layout
 
 - `data/` – raw fixtures and results.

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -309,3 +309,39 @@ def test_simulate_final_table_deterministic():
     pd.testing.assert_frame_equal(table1, table2)
     assert {"team", "position", "points"}.issubset(table1.columns)
     assert len(table1) == len(pd.unique(df[["home_team", "away_team"]].values.ravel()))
+
+
+def test_league_table_goal_difference_tiebreak():
+    data = [
+        {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 1, "away_score": 2},
+        {"date": "2025-01-02", "home_team": "A", "away_team": "C", "home_score": 1, "away_score": 0},
+        {"date": "2025-01-03", "home_team": "C", "away_team": "A", "home_score": 0, "away_score": 1},
+        {"date": "2025-01-04", "home_team": "B", "away_team": "C", "home_score": 3, "away_score": 0},
+    ]
+    df = pd.DataFrame(data)
+    table = league_table(df)
+    assert list(table.team[:2]) == ["B", "A"]
+
+
+def test_league_table_goals_scored_tiebreak():
+    data = [
+        {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 0, "away_score": 0},
+        {"date": "2025-01-02", "home_team": "B", "away_team": "A", "home_score": 0, "away_score": 0},
+        {"date": "2025-01-03", "home_team": "A", "away_team": "C", "home_score": 1, "away_score": 0},
+        {"date": "2025-01-04", "home_team": "B", "away_team": "C", "home_score": 2, "away_score": 1},
+    ]
+    df = pd.DataFrame(data)
+    table = league_table(df)
+    assert list(table.team[:2]) == ["B", "A"]
+
+
+def test_league_table_head_to_head_tiebreak():
+    data = [
+        {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 0, "away_score": 0},
+        {"date": "2025-01-02", "home_team": "B", "away_team": "A", "home_score": 1, "away_score": 0},
+        {"date": "2025-01-03", "home_team": "A", "away_team": "C", "home_score": 1, "away_score": 0},
+        {"date": "2025-01-04", "home_team": "B", "away_team": "C", "home_score": 0, "away_score": 1},
+    ]
+    df = pd.DataFrame(data)
+    table = league_table(df)
+    assert list(table.team[:2]) == ["B", "A"]


### PR DESCRIPTION
## Summary
- sort league tables by points, wins, goal difference, goals scored, head-to-head points and team name
- compute head-to-head points for tied teams
- update leader calculation to rely on `league_table`
- document tie-break rules
- add unit tests for goal difference, goals scored and head-to-head scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729a9c68b08325a8b86e8c8bd50beb