### PR TITLE
Add Elo home field advantage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ reproduce a specific simulation. You can also specify team-specific home
 advantage multipliers by passing a dictionary to the `team_home_advantages`
 argument of `simulate_chances`. The `leader_history` rating method adjusts
 strengths based on how often teams led past seasons; configure its behaviour
-with `--leader-history-paths` and `--leader-weight`.
+with `--leader-history-paths` and `--leader-weight`. When using Elo ratings you
+may set a base home field bonus in rating points via the `home_field_advantage`
+function parameter or the `--elo-home-advantage` CLI option.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/main.py
+++ b/main.py
@@ -45,6 +45,12 @@ def main() -> None:
         help="Elo K factor when using the 'elo' rating method",
     )
     parser.add_argument(
+        "--elo-home-advantage",
+        type=float,
+        default=0.0,
+        help="Rating points added to the home team in Elo calculations",
+    )
+    parser.add_argument(
         "--leader-history-paths",
         nargs="*",
         default=["data/Brasileirao2024A.txt"],
@@ -66,6 +72,7 @@ def main() -> None:
         rating_method=args.rating,
         rng=rng,
         elo_k=args.elo_k,
+        home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
     )
@@ -76,6 +83,7 @@ def main() -> None:
         rating_method=args.rating,
         rng=rng,
         elo_k=args.elo_k,
+        home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
     )
@@ -86,6 +94,7 @@ def main() -> None:
         rating_method=args.rating,
         rng=rng,
         elo_k=args.elo_k,
+        home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -211,6 +211,28 @@ def test_team_home_advantage_changes_results():
     assert base != custom
 
 
+def test_home_field_advantage_changes_elo_results():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(22)
+    base = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="elo",
+        rng=rng,
+        elo_k=20.0,
+    )
+    rng = np.random.default_rng(22)
+    adv = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="elo",
+        rng=rng,
+        elo_k=20.0,
+        home_field_advantage=50.0,
+    )
+    assert base != adv
+
+
 def test_simulate_chances_dixon_coles_seed_repeatability():
     df = parse_matches("data/Brasileirao2025A.txt")
     rng = np.random.default_rng(123)


### PR DESCRIPTION
## Summary
- allow configuring Elo home-field bonus
- document the new option
- expose CLI flag `--elo-home-advantage`
- test that Elo probabilities change with different home advantages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876db1ce4a88325967dc6578af8f4d2