### PR TITLE
Add deterministic summary_table test

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -833,6 +833,7 @@ def simulate_final_table(
     rating_method: str = "ratio",
     rng: np.random.Generator | None = None,
     elo_k: float = 20.0,
+    home_field_advantage: float = 0.0,
     team_home_advantages: dict[str, float] | None = None,
     leader_history_paths: list[str | Path] | None = None,
     leader_history_weight: float = 0.5,
@@ -844,6 +845,7 @@ def simulate_final_table(
     contains the average finishing position and point total of each club,
     sorted by expected position.
     ``smooth`` has the same meaning as in :func:`simulate_chances`.
+    ``home_field_advantage`` only affects the Elo method.
     """
 
     if rng is None:

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -353,6 +353,16 @@ def test_simulate_final_table_deterministic():
     assert len(table1) == len(pd.unique(df[["home_team", "away_team"]].values.ravel()))
 
 
+def test_summary_table_deterministic_columns():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(123)
+    table1 = simulator.summary_table(df, iterations=5, rng=rng)
+    rng = np.random.default_rng(123)
+    table2 = simulator.summary_table(df, iterations=5, rng=rng)
+    pd.testing.assert_frame_equal(table1, table2)
+    assert {"position", "team", "points", "title", "relegation"}.issubset(table1.columns)
+
+
 def test_league_table_goal_difference_tiebreak():
     data = [
         {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 1, "away_score": 2},


### PR DESCRIPTION
## Summary
- add a regression test for `summary_table`
- allow `simulate_final_table` to receive a home field advantage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876e05acc00832597eba15bcaa7ea7c