### PR TITLE
Improve negative binomial support

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -177,6 +177,15 @@ def test_simulate_chances_neg_binom_seed_repeatability():
     assert abs(sum(chances1.values()) - 1.0) < 1e-6
 
 
+def test_neg_binom_differs_from_poisson():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(123)
+    poisson_res = simulate_chances(df, iterations=50, rating_method="poisson", rng=rng)
+    rng = np.random.default_rng(123)
+    nb_res = simulate_chances(df, iterations=50, rating_method="neg_binom", rng=rng)
+    assert poisson_res != nb_res
+
+
 def test_simulate_chances_skellam_seed_repeatability():
     df = parse_matches('data/Brasileirao2025A.txt')
     rng = np.random.default_rng(66)


### PR DESCRIPTION
## Summary
- implement `_estimate_dispersion` for method-of-moments NB dispersion
- sample from negative binomial when using `neg_binom` rating
- expose dispersion via `get_strengths`
- add regression test checking difference from Poisson

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687988aaf7d48325b06c43ae6754e3d1