### PR TITLE
Reuse team home advantage calculations

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -267,6 +267,16 @@ def _estimate_team_home_advantages(matches: pd.DataFrame) -> dict[str, float]:
     return factors
 
 
+def _prepare_team_home_advantages(
+    matches: pd.DataFrame, team_home_advantages: dict[str, float] | None
+) -> dict[str, float]:
+    """Return home advantage factors merging estimates with custom values."""
+    base = _estimate_team_home_advantages(matches)
+    if team_home_advantages:
+        base.update(team_home_advantages)
+    return base
+
+
 def _estimate_dispersion(matches: pd.DataFrame) -> float:
     """Return method-of-moments dispersion for Negative Binomial sampling."""
     played = matches.dropna(subset=["home_score", "away_score"])
@@ -791,12 +801,9 @@ def simulate_chances(
     if rng is None:
         rng = np.random.default_rng()
 
-    if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
-    else:
-        merged = _estimate_team_home_advantages(matches)
-        merged.update(team_home_advantages)
-        team_home_advantages = merged
+    team_home_advantages = _prepare_team_home_advantages(
+        matches, team_home_advantages
+    )
 
     strengths, avg_goals, home_adv, extra_param = get_strengths(
         matches,
@@ -858,12 +865,9 @@ def simulate_relegation_chances(
     if rng is None:
         rng = np.random.default_rng()
 
-    if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
-    else:
-        merged = _estimate_team_home_advantages(matches)
-        merged.update(team_home_advantages)
-        team_home_advantages = merged
+    team_home_advantages = _prepare_team_home_advantages(
+        matches, team_home_advantages
+    )
 
     strengths, avg_goals, home_adv, extra_param = get_strengths(
         matches,
@@ -925,12 +929,9 @@ def simulate_final_table(
     if rng is None:
         rng = np.random.default_rng()
 
-    if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
-    else:
-        merged = _estimate_team_home_advantages(matches)
-        merged.update(team_home_advantages)
-        team_home_advantages = merged
+    team_home_advantages = _prepare_team_home_advantages(
+        matches, team_home_advantages
+    )
 
     strengths, avg_goals, home_adv, extra_param = get_strengths(
         matches,

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -244,6 +244,22 @@ def test_team_home_advantage_changes_results():
     assert base != custom
 
 
+def test_reuse_team_home_advantages():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    adv = simulator._estimate_team_home_advantages(df)
+    rng = np.random.default_rng(15)
+    with_adv = simulate_chances(df, iterations=5, rng=rng, team_home_advantages=adv)
+    rng = np.random.default_rng(15)
+    auto = simulate_chances(df, iterations=5, rng=rng)
+    assert with_adv == auto
+
+    rng = np.random.default_rng(15)
+    table_adv = simulator.simulate_final_table(df, iterations=5, rng=rng, team_home_advantages=adv)
+    rng = np.random.default_rng(15)
+    table_auto = simulator.simulate_final_table(df, iterations=5, rng=rng)
+    pd.testing.assert_frame_equal(table_adv, table_auto)
+
+
 def test_home_field_advantage_changes_elo_results():
     df = parse_matches("data/Brasileirao2025A.txt")
     rng = np.random.default_rng(22)


### PR DESCRIPTION
## Summary
- add helper `_prepare_team_home_advantages`
- reuse precomputed home advantage factors in simulation functions
- test that passing precomputed factors gives identical results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da93d86508325a442c3b73d99b735