### PR TITLE
Add docstring and reorder imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
-import argparse
+"""Command-line interface for running Brasileir\u00e3o simulations."""
+
+# pylint: disable=wrong-import-position
+
 import os
 import sys
-import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+import argparse
+import numpy as np
 from brasileirao import (
     parse_matches,
     simulate_chances,


### PR DESCRIPTION
## Summary
- document what `main.py` does
- move the dynamic path insertion ahead of imports
- silence `wrong-import-position` so pylint passes

## Testing
- `pylint main.py`

------
https://chatgpt.com/codex/tasks/task_e_688810f343448325ab943df03c6e6390