### PR TITLE
Add smoothing and baseline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ pip install -r requirements.txt
 python main.py --simulations 1000
 ```
 
+You can customise the strength estimation with additional options. For example:
+
+```bash
+python main.py --simulations 1000 --smooth 2 \
+    --home-smooth 1 --avg-goals-baseline 2.6 --home-adv-baseline 1.05
+```
+
 The simulator uses a rating model similar to the one employed by SportsClubStats. Team attack and defence strengths are based on goals scored and conceded so far in the season. Remaining fixtures are simulated with Poisson-distributed scores using these strengths.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated. It also estimates the average final position and points of every club.

--- a/main.py
+++ b/main.py
@@ -29,13 +29,70 @@ def main() -> None:
         default=None,
         help="random seed for repeatable simulations",
     )
+    parser.add_argument(
+        "--smooth",
+        type=float,
+        default=1.0,
+        help="strength smoothing factor",
+    )
+    parser.add_argument(
+        "--avg-goals-baseline",
+        type=float,
+        default=2.5,
+        help="baseline average goals when no data",
+    )
+    parser.add_argument(
+        "--home-adv-baseline",
+        type=float,
+        default=1.0,
+        help="baseline league home advantage",
+    )
+    parser.add_argument(
+        "--home-smooth",
+        type=float,
+        default=0.0,
+        help="smoothing factor for team home advantage",
+    )
+    parser.add_argument(
+        "--home-baseline",
+        type=float,
+        default=None,
+        help="override baseline for team home advantage",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
     rng = np.random.default_rng(args.seed) if args.seed is not None else None
-    chances = simulate_chances(matches, iterations=args.simulations, rng=rng)
-    relegation = simulate_relegation_chances(matches, iterations=args.simulations, rng=rng)
-    table_proj = simulate_final_table(matches, iterations=args.simulations, rng=rng)
+    chances = simulate_chances(
+        matches,
+        iterations=args.simulations,
+        rng=rng,
+        smooth=args.smooth,
+        avg_goals_baseline=args.avg_goals_baseline,
+        home_adv_baseline=args.home_adv_baseline,
+        home_smooth=args.home_smooth,
+        home_baseline=args.home_baseline,
+    )
+    relegation = simulate_relegation_chances(
+        matches,
+        iterations=args.simulations,
+        rng=rng,
+        smooth=args.smooth,
+        avg_goals_baseline=args.avg_goals_baseline,
+        home_adv_baseline=args.home_adv_baseline,
+        home_smooth=args.home_smooth,
+        home_baseline=args.home_baseline,
+    )
+    table_proj = simulate_final_table(
+        matches,
+        iterations=args.simulations,
+        rng=rng,
+        smooth=args.smooth,
+        avg_goals_baseline=args.avg_goals_baseline,
+        home_adv_baseline=args.home_adv_baseline,
+        home_smooth=args.home_smooth,
+        home_baseline=args.home_baseline,
+    )
 
     summary = table_proj.copy()
     summary["title"] = summary["team"].map(chances)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -64,6 +64,30 @@ def test_estimate_strengths_zero_goals():
     assert strengths["C"]["defense"] > 0
 
 
+def test_estimate_strengths_custom_baselines():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    s1, ag1, ha1 = simulator._estimate_strengths(
+        df,
+        smooth=2.0,
+        avg_goals_baseline=3.0,
+        home_adv_baseline=1.1,
+    )
+    s2, ag2, ha2 = simulator._estimate_strengths(
+        df,
+        smooth=2.0,
+        avg_goals_baseline=3.0,
+        home_adv_baseline=1.1,
+    )
+    assert s1 == s2 and ag1 == ag2 and ha1 == ha2
+
+
+def test_estimate_team_home_advantages_custom():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    adv = simulator._estimate_team_home_advantages(df, smooth=1.0, baseline=1.1)
+    teams = pd.unique(df[["home_team", "away_team"]].values.ravel())
+    assert set(adv.keys()) == set(teams)
+
+
 def test_simulate_relegation_chances_sum_to_four():
     df = parse_matches('data/Brasileirao2025A.txt')
     probs = simulator.simulate_relegation_chances(df, iterations=10)


### PR DESCRIPTION
## Summary
- allow passing baseline strengths and smoothing
- update CLI to expose the new options
- document how to use custom smoothing in README
- expand simulator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688817bb4d948325aafa34d417baf71e