### PR TITLE
Adjust home advantage default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ You can customise the strength estimation with additional options. For example:
 
 ```bash
 python main.py --simulations 1000 --smooth 2 \
-    --home-smooth 1 --avg-goals-baseline 2.6 --home-adv-baseline 1.05
+    --home-smooth 1 --avg-goals-baseline 2.6 --home-adv-baseline 1.3
 ```
+
+The default home advantage baseline is ``1.3``, roughly matching the
+average home advantage observed in recent Série A seasons.
 
 The simulator uses a rating model similar to the one employed by SportsClubStats. Team attack and defence strengths are based on goals scored and conceded so far in the season. Remaining fixtures are simulated with Poisson-distributed scores using these strengths.
 

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ def main() -> None:
     parser.add_argument(
         "--home-adv-baseline",
         type=float,
-        default=1.0,
+        default=1.3,
         help="baseline league home advantage",
     )
     parser.add_argument(

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -295,7 +295,7 @@ def simulate_chances(
     team_home_advantages: Dict[str, float] | None = None,
     smooth: float = 1.0,
     avg_goals_baseline: float = 2.5,
-    home_adv_baseline: float = 1.0,
+    home_adv_baseline: float = 1.3,
     home_smooth: float = 0.0,
     home_baseline: float | None = None,
 ) -> Dict[str, float]:
@@ -347,7 +347,7 @@ def simulate_relegation_chances(
     team_home_advantages: Dict[str, float] | None = None,
     smooth: float = 1.0,
     avg_goals_baseline: float = 2.5,
-    home_adv_baseline: float = 1.0,
+    home_adv_baseline: float = 1.3,
     home_smooth: float = 0.0,
     home_baseline: float | None = None,
 ) -> Dict[str, float]:
@@ -400,7 +400,7 @@ def simulate_final_table(
     team_home_advantages: Dict[str, float] | None = None,
     smooth: float = 1.0,
     avg_goals_baseline: float = 2.5,
-    home_adv_baseline: float = 1.0,
+    home_adv_baseline: float = 1.3,
     home_smooth: float = 0.0,
     home_baseline: float | None = None,
 ) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- bump `home_adv_baseline` default to 1.3 in simulation functions
- update CLI default and README docs to mention new baseline

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68881c183c848325bec921fd8f6db26a